### PR TITLE
Update methods to add and remove collaborators for QA apps

### DIFF
--- a/lib/taskmaster/heroku/app.rb
+++ b/lib/taskmaster/heroku/app.rb
@@ -52,7 +52,7 @@ module Taskmaster
       def add_collaborators(*collaborators)
         Bundler.with_clean_env do
           collaborators.each do |collaborator|
-            puts `heroku sharing:add #{collaborator} -a #{@app_name}`
+            puts `heroku access:add #{collaborator} -a #{@app_name}`
           end
         end
       end
@@ -60,7 +60,7 @@ module Taskmaster
       def remove_collaborators(*collaborators)
         Bundler.with_clean_env do
           collaborators.each do |collaborator|
-            puts `heroku sharing:remove #{collaborator} -a #{@app_name}`
+            puts `heroku access:remove #{collaborator} -a #{@app_name}`
           end
         end
       end

--- a/lib/taskmaster/version.rb
+++ b/lib/taskmaster/version.rb
@@ -1,3 +1,3 @@
 module Taskmaster
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
Heroku says we now have to use `heroku access:add` and `heroku access:remove` to manage app collaborators. 