### PR TITLE
adding webpacker manifest to Asset Manifest commit

### DIFF
--- a/lib/taskmaster/heroku.rb
+++ b/lib/taskmaster/heroku.rb
@@ -36,6 +36,7 @@ module Taskmaster
           ]
         end
         Taskmaster.repo.add('public/assets/manifest-1.json')
+        Taskmaster.repo.add('public/assets/packs/manifest.json')
         Taskmaster.repo.commit('Assets Manifest updated. [ci skip]')
       end
       @deploy_prepared = true


### PR DESCRIPTION
* `public/assets/packs/manifest.json` will no longer have to be managed with every CIO pull that changes webpacker assets